### PR TITLE
Restructured Month Heirarchy

### DIFF
--- a/src/Data/Parser.php
+++ b/src/Data/Parser.php
@@ -16,7 +16,7 @@ class Parser {
 
   private $classPaths = [
     'custom' => null,
-    'standard' => '\\Skybluesofa\\OnThisDay\\Data\\Month',
+    'standard' => '\\Skybluesofa\\OnThisDay\\Data\\Region',
   ];
   private $useStandardEvents = true;
 
@@ -80,7 +80,7 @@ class Parser {
     }
 
     $monthName = date("F", mktime(0, 0, 0, $this->carbonDate->month, 1));
-    $classPath = $this->classPaths[$classType].$this->getLocalePath().$monthName;
+    $classPath = $this->classPaths[$classType].$this->getLocalePath()."Month\\".$monthName;
 
     if (!class_exists($classPath)) {
       return false;

--- a/src/Data/Region/En/Us/Month/April.php
+++ b/src/Data/Region/En/Us/Month/April.php
@@ -1,9 +1,9 @@
 <?php
-namespace Skybluesofa\OnThisDay\Data\Month\En\Us;
+namespace Skybluesofa\OnThisDay\Data\Region\En\Us\Month;
 
 use Skybluesofa\OnThisDay\Data\Contract\Month;
 
-class July extends Month {
+class April extends Month {
     public static $recurringEvents = [];
 
     public static $specificDateEvents = [];

--- a/src/Data/Region/En/Us/Month/August.php
+++ b/src/Data/Region/En/Us/Month/August.php
@@ -1,9 +1,9 @@
 <?php
-namespace Skybluesofa\OnThisDay\Data\Month\En\Us;
+namespace Skybluesofa\OnThisDay\Data\Region\En\Us\Month;
 
 use Skybluesofa\OnThisDay\Data\Contract\Month;
 
-class March extends Month {
+class August extends Month {
     public static $recurringEvents = [];
 
     public static $specificDateEvents = [];

--- a/src/Data/Region/En/Us/Month/December.php
+++ b/src/Data/Region/En/Us/Month/December.php
@@ -1,5 +1,5 @@
 <?php
-namespace Skybluesofa\OnThisDay\Data\Month\En\Us;
+namespace Skybluesofa\OnThisDay\Data\Region\En\Us\Month;
 
 use Skybluesofa\OnThisDay\Data\Contract\Month;
 

--- a/src/Data/Region/En/Us/Month/February.php
+++ b/src/Data/Region/En/Us/Month/February.php
@@ -1,5 +1,5 @@
 <?php
-namespace Skybluesofa\OnThisDay\Data\Month\En\Us;
+namespace Skybluesofa\OnThisDay\Data\Region\En\Us\Month;
 
 use Skybluesofa\OnThisDay\Data\Contract\Month;
 

--- a/src/Data/Region/En/Us/Month/January.php
+++ b/src/Data/Region/En/Us/Month/January.php
@@ -1,5 +1,5 @@
 <?php
-namespace Skybluesofa\OnThisDay\Data\Month\En\Us;
+namespace Skybluesofa\OnThisDay\Data\Region\En\Us\Month;
 
 use Skybluesofa\OnThisDay\Data\Contract\Month;
 

--- a/src/Data/Region/En/Us/Month/July.php
+++ b/src/Data/Region/En/Us/Month/July.php
@@ -1,9 +1,9 @@
 <?php
-namespace Skybluesofa\OnThisDay\Data\Month\En\Us;
+namespace Skybluesofa\OnThisDay\Data\Region\En\Us\Month;
 
 use Skybluesofa\OnThisDay\Data\Contract\Month;
 
-class April extends Month {
+class July extends Month {
     public static $recurringEvents = [];
 
     public static $specificDateEvents = [];

--- a/src/Data/Region/En/Us/Month/June.php
+++ b/src/Data/Region/En/Us/Month/June.php
@@ -1,9 +1,9 @@
 <?php
-namespace Skybluesofa\OnThisDay\Data\Month\En\Us;
+namespace Skybluesofa\OnThisDay\Data\Region\En\Us\Month;
 
 use Skybluesofa\OnThisDay\Data\Contract\Month;
 
-class August extends Month {
+class June extends Month {
     public static $recurringEvents = [];
 
     public static $specificDateEvents = [];

--- a/src/Data/Region/En/Us/Month/March.php
+++ b/src/Data/Region/En/Us/Month/March.php
@@ -1,25 +1,20 @@
 <?php
-
-namespace Skybluesofa\OnThisDay\Tests\Custom\En\Us;
+namespace Skybluesofa\OnThisDay\Data\Region\En\Us\Month;
 
 use Skybluesofa\OnThisDay\Data\Contract\Month;
 
-class July extends Month
-{
-    public static $recurringEvents = [
-        "1" => ["Some Custom Event"],
-    ];
-
-    public static $recurringHolidays = [];
+class March extends Month {
+    public static $recurringEvents = [];
 
     public static $specificDateEvents = [];
+
+    public static $specificDateHolidays = [];
 
     public static $configurationEvents = [];
 
     public static $configurationHolidays = [];
 
-    protected function getRecurringAdvancedConfigurationBasedEvents(\Carbon\Carbon $date)
-    {
+    protected function getRecurringAdvancedConfigurationBasedEvents(\Carbon\Carbon $date) {
         $events = [];
         return $events;
     }

--- a/src/Data/Region/En/Us/Month/May.php
+++ b/src/Data/Region/En/Us/Month/May.php
@@ -1,9 +1,9 @@
 <?php
-namespace Skybluesofa\OnThisDay\Data\Month\En\Us;
+namespace Skybluesofa\OnThisDay\Data\Region\En\Us\Month;
 
 use Skybluesofa\OnThisDay\Data\Contract\Month;
 
-class June extends Month {
+class May extends Month {
     public static $recurringEvents = [];
 
     public static $specificDateEvents = [];

--- a/src/Data/Region/En/Us/Month/November.php
+++ b/src/Data/Region/En/Us/Month/November.php
@@ -1,5 +1,5 @@
 <?php
-namespace Skybluesofa\OnThisDay\Data\Month\En\Us;
+namespace Skybluesofa\OnThisDay\Data\Region\En\Us\Month;
 
 use Skybluesofa\OnThisDay\Data\Contract\Month;
 

--- a/src/Data/Region/En/Us/Month/October.php
+++ b/src/Data/Region/En/Us/Month/October.php
@@ -1,5 +1,5 @@
 <?php
-namespace Skybluesofa\OnThisDay\Data\Month\En\Us;
+namespace Skybluesofa\OnThisDay\Data\Region\En\Us\Month;
 
 use Skybluesofa\OnThisDay\Data\Contract\Month;
 

--- a/src/Data/Region/En/Us/Month/September.php
+++ b/src/Data/Region/En/Us/Month/September.php
@@ -1,5 +1,5 @@
 <?php
-namespace Skybluesofa\OnThisDay\Data\Month\En\Us;
+namespace Skybluesofa\OnThisDay\Data\Region\En\Us\Month;
 
 use Skybluesofa\OnThisDay\Data\Contract\Month;
 

--- a/tests/Custom/En/Us/Month/July.php
+++ b/tests/Custom/En/Us/Month/July.php
@@ -1,20 +1,25 @@
 <?php
-namespace Skybluesofa\OnThisDay\Data\Month\En\Us;
+
+namespace Skybluesofa\OnThisDay\Tests\Custom\En\Us\Month;
 
 use Skybluesofa\OnThisDay\Data\Contract\Month;
 
-class May extends Month {
-    public static $recurringEvents = [];
+class July extends Month
+{
+    public static $recurringEvents = [
+        "1" => ["Some Custom Event"],
+    ];
+
+    public static $recurringHolidays = [];
 
     public static $specificDateEvents = [];
-
-    public static $specificDateHolidays = [];
 
     public static $configurationEvents = [];
 
     public static $configurationHolidays = [];
 
-    protected function getRecurringAdvancedConfigurationBasedEvents(\Carbon\Carbon $date) {
+    protected function getRecurringAdvancedConfigurationBasedEvents(\Carbon\Carbon $date)
+    {
         $events = [];
         return $events;
     }

--- a/tests/OnThisDayTest.php
+++ b/tests/OnThisDayTest.php
@@ -4,48 +4,48 @@ use Carbon\Carbon;
 
 class OnThisDayTest extends PHPUnit_Framework_TestCase {
 	function test_january_data() {
-		$this->assertFileExists(__DIR__.'/../src/Data/Month/En/Us/January.php');
+		$this->assertFileExists(__DIR__.'/../src/Data/Region/En/Us/Month/January.php');
 		$this->assertNotContains ("New Year's Day", OnThisDay::getEvents('1/1/2016'));
 		$this->assertContains ("New Year's Day", OnThisDay::getHolidays('1/1/2016'));
 		$this->assertContains ("New Year's Day", OnThisDay::setLocale('en_US')->getHolidays('1/1/2016'));
 	}
 	function test_february_data() {
-		$this->assertFileExists(__DIR__.'/../src/Data/Month/En/Us/February.php');
+		$this->assertFileExists(__DIR__.'/../src/Data/Region/En/Us/Month/February.php');
 		$this->assertContains ("Valentine's Day", OnThisDay::getEvents('2/14/2016'));
 	}
 	function test_march_data() {
-		$this->assertFileExists(__DIR__.'/../src/Data/Month/En/Us/March.php');
+		$this->assertFileExists(__DIR__.'/../src/Data/Region/En/Us/Month/March.php');
 	}
 	function test_april_data() {
-		$this->assertFileExists(__DIR__.'/../src/Data/Month/En/Us/April.php');
+		$this->assertFileExists(__DIR__.'/../src/Data/Region/En/Us/Month/April.php');
 	}
 	function test_may_data() {
-		$this->assertFileExists(__DIR__.'/../src/Data/Month/En/Us/May.php');
+		$this->assertFileExists(__DIR__.'/../src/Data/Region/En/Us/Month/May.php');
 	}
 	function test_june_data() {
-		$this->assertFileExists(__DIR__.'/../src/Data/Month/En/Us/June.php');
+		$this->assertFileExists(__DIR__.'/../src/Data/Region/En/Us/Month/June.php');
 	}
 	function test_july_data() {
-		$this->assertFileExists(__DIR__.'/../tests/Custom/En/Us/July.php');
+		$this->assertFileExists(__DIR__.'/../tests/Custom/En/Us/Month/July.php');
 		$events = OnThisDay::useCustomEvents("Skybluesofa\OnThisDay\Tests\Custom")->getEvents('7/1/2016');
 		$this->assertContains ("Some Custom Event", $events);
 		$events = OnThisDay::useCustomEvents("Skybluesofa\OnThisDay\Tests\Custom")->withStandardEvents(false)->getEvents('7/1/2016');
 		$this->assertContains ("Some Custom Event", $events);
 	}
 	function test_august_data() {
-		$this->assertFileExists(__DIR__.'/../src/Data/Month/En/Us/August.php');
+		$this->assertFileExists(__DIR__.'/../src/Data/Region/En/Us/Month/August.php');
 	}
 	function test_september_data() {
-		$this->assertFileExists(__DIR__.'/../src/Data/Month/En/Us/September.php');
+		$this->assertFileExists(__DIR__.'/../src/Data/Region/En/Us/Month/September.php');
 	}
 	function test_october_data() {
-		$this->assertFileExists(__DIR__.'/../src/Data/Month/En/Us/October.php');
+		$this->assertFileExists(__DIR__.'/../src/Data/Region/En/Us/Month/October.php');
 		$this->assertNotContains ('Halloween', OnThisDay::getEvents('10/31/2016'));
 		$this->assertContains ('Halloween', OnThisDay::getHolidays('10/31/2016'));
 		$this->assertContains ('Halloween', OnThisDay::getEventsAndHolidays('10/31/2016'));
 	}
 	function test_november_data() {
-		$this->assertFileExists(__DIR__.'/../src/Data/Month/En/Us/November.php');
+		$this->assertFileExists(__DIR__.'/../src/Data/Region/En/Us/Month/November.php');
 		$this->assertContains ('Men Make Dinner Day', OnThisDay::getEvents('11/3/2016'));
 		$this->assertContains ('Take A Hike Day', OnThisDay::getEvents('11/17/2016'));
 		$this->assertContains ('Black Friday', OnThisDay::getEvents('11/25/2016'));
@@ -54,7 +54,12 @@ class OnThisDayTest extends PHPUnit_Framework_TestCase {
 		$this->assertContains ('Thanksgiving', OnThisDay::getEventsAndHolidays('11/24/2016'));
 	}
 	function test_december_data() {
-		$this->assertFileExists(__DIR__.'/../src/Data/Month/En/Us/December.php');
+		$this->assertFileExists(__DIR__.'/../src/Data/Region/En/Us/Month/December.php');
+		$this->assertContains ('National Cookie Day', OnThisDay::getEvents('12/4/2016'));
+		$this->assertNotContains ('Monkey Day', OnThisDay::getEvents('12/4/2016'));
+		$this->assertNotContains ('Christmas', OnThisDay::getEvents('12/25/2016'));
+		$this->assertContains ('Christmas', OnThisDay::getHolidays('12/25/2016'));
+		$this->assertContains ('Christmas', OnThisDay::getEventsAndHolidays('12/25/2016'));
 	}
 	function test_when_is_event() {
 		/*


### PR DESCRIPTION
Moved files from the src/Data/Month/En/Us/ folder to the
src/Data/Region/En/Us/Month folder. This should help keep all
information for a given region together as there are new ‘helper’
classes coming down the pike.